### PR TITLE
Fix to manage a nil access token callback error. 

### DIFF
--- a/AlamofireOauth2/OAuth2Client.swift
+++ b/AlamofireOauth2/OAuth2Client.swift
@@ -76,6 +76,9 @@ class OAuth2Client : NSObject {
 //                        self.postRequestHandler(result.value, error: result.error, token: token)
 //                }
             }
+            else {
+                token(accessToken: nil)
+            }
         })
     }
     


### PR DESCRIPTION
This for example happens when in the Linkedin login form the user insert a mail and add a space at the end. The oauth fails, the token is null, but the OAuth2Client class don't call the error clousure, so the error couldn't be managed from the app usign this lib.
