### PR TITLE
Explicitly request application/json when fetching a token; fixes GitH…

### DIFF
--- a/AlamofireOauth2/OAuth2Client.swift
+++ b/AlamofireOauth2/OAuth2Client.swift
@@ -61,7 +61,10 @@ class OAuth2Client : NSObject {
                 Alamofire.request(.POST,
                     url, 
                     parameters: parameters,
-                    encoding: Alamofire.ParameterEncoding.URL)
+                    encoding: Alamofire.ParameterEncoding.URL,
+                    headers: [
+                        "Accept": "application/json",
+                    ])
                     .responseJSON(completionHandler: { (response) -> Void in
                         switch response.result {
                         case .Success(let json):
@@ -167,7 +170,10 @@ class OAuth2Client : NSObject {
         Alamofire.request(.POST,
             url, 
             parameters: parameters,
-            encoding: Alamofire.ParameterEncoding.URL)
+            encoding: Alamofire.ParameterEncoding.URL,
+            headers: [
+                "Accept": "application/json",
+            ])
             .responseJSON { (response) -> Void in
                 switch response.result {
                 case .Success(let json):


### PR DESCRIPTION
…ub login.

Backstory: by default, [GitHub returns a URLencoded token response](https://developer.github.com/v3/oauth/#response) when fetching an access token. In order to retrieve JSON, an "Accept: application/json" header must be present.
