### PR TITLE
1 typo: 'WorPress' -> 'WordPress'

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pod install
 and you are ready to go!
 
 ## How to use the AlamofireOauth
-Below is the sample code for a simple call to the WorPress API while authenticating using OAuth2
+Below is the sample code for a simple call to the WordPress API while authenticating using OAuth2
 
 
 ```Swift


### PR DESCRIPTION
With this, there are no more typos on the internet, and I can finally sleep at night.
;)